### PR TITLE
feature: add connid object buider wrapper

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
 
 	<groupId>com.evolveum.polygon.scim</groupId>
-	<version>1.4.4.1</version>
+	<version>1.4.4.2</version>
 	<packaging>jar</packaging>
 
 	<name>connector-scim</name>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,11 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-			</plugin>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-resources-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@
 	<url>http://maven.apache.org</url>
 
 	<properties>
-		<maven.compiler.source>1.7</maven.compiler.source>
-		<maven.compiler.target>1.7</maven.compiler.target>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 
@@ -31,6 +31,10 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/com/evolveum/polygon/scim/StandardScimHandlingStrategy.java
+++ b/src/main/java/com/evolveum/polygon/scim/StandardScimHandlingStrategy.java
@@ -81,6 +81,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import com.evolveum.polygon.scim.ErrorHandler;
+import com.evolveum.polygon.scim.common.ConnectorObjectBuilderWrapper;
 import com.evolveum.polygon.scim.common.HttpPatch;
 
 
@@ -1145,24 +1146,22 @@ public class StandardScimHandlingStrategy implements HandlingStrategy {
 					"Empty json object was passed from data provider. Error ocourance while building connector object");
 		}
 
-		ConnectorObjectBuilder cob = new ConnectorObjectBuilder();
-		cob.setUid(resourceJsonObject.getString(ID));
-		excludedAttributes.add(ID);
+		ConnectorObjectBuilderWrapper cob;
 		if (USERS.equals(resourceEndPoint)) {
+			cob = new ConnectorObjectBuilderWrapper(ObjectClass.ACCOUNT);
 			cob.setName(resourceJsonObject.getString(USERNAME));
 			excludedAttributes.add(USERNAME);
 		} else if (GROUPS.equals(resourceEndPoint)) {
-
+			cob = new ConnectorObjectBuilderWrapper(ObjectClass.GROUP);
 			cob.setName(resourceJsonObject.getString(DISPLAYNAME));
 			excludedAttributes.add(DISPLAYNAME);
-			cob.setObjectClass(ObjectClass.GROUP);
 		} else {
-			cob.setName(resourceJsonObject.getString(DISPLAYNAME));
-			excludedAttributes.add(DISPLAYNAME);
-			ObjectClass objectClass = new ObjectClass(resourceEndPoint);
-			cob.setObjectClass(objectClass);
-
+			ObjectClass objClass = new ObjectClass(resourceEndPoint);
+			LOGGER.error("Unsupported class: {0}, oclass.getDisplayNameKey()", objClass.getDisplayNameKey());
+            throw new ConnectorException("Unsupported class to build connector object");
 		}
+		cob.setUid(resourceJsonObject.getString(ID));
+		excludedAttributes.add(ID);
 		for (String key : resourceJsonObject.keySet()) {
 			Object attribute = resourceJsonObject.get(key);
 

--- a/src/main/java/com/evolveum/polygon/scim/common/ConnectorObjectBuilderWrapper.java
+++ b/src/main/java/com/evolveum/polygon/scim/common/ConnectorObjectBuilderWrapper.java
@@ -1,0 +1,143 @@
+package com.evolveum.polygon.scim.common;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import org.identityconnectors.common.logging.Log;
+import org.identityconnectors.framework.common.exceptions.ConnectorException;
+import org.identityconnectors.framework.common.objects.*;
+
+import com.evolveum.polygon.scim.UserSchemaBuilder;
+import com.evolveum.polygon.scim.GroupDataBuilder;
+
+
+/**
+ * @author Vlad Kislitsyn
+ * 
+ *         Wrapper class for class ConnectorObject
+ *         Validates attributes based on schema definition
+ */
+
+public class ConnectorObjectBuilderWrapper {
+
+    private static final Log LOGGER = Log.getLog(ConnectorObjectBuilderWrapper.class);
+
+    final private Set<String> attributesName;
+    final private ConnectorObjectBuilder cob;
+    final private ObjectClass oclass;
+    final private List<String> missedAttributes = new ArrayList<>();
+
+    public ConnectorObjectBuilderWrapper(ObjectClass oclass) {
+        this.oclass = oclass;
+        ObjectClassInfo schema;
+        if (ObjectClass.ACCOUNT.equals(oclass)) {
+            schema = UserSchemaBuilder.getUserSchema();
+        }
+        else if (ObjectClass.GROUP.equals(oclass)) {
+            schema = GroupDataBuilder.getGroupSchema();
+        }
+        else {
+            LOGGER.error("Unsupported object class: {0}. Schema is not defined", oclass.getDisplayNameKey());
+            throw new ConnectorException("Unsupported object class");
+        }
+        this.attributesName = schema.getAttributeInfo()
+                .stream()
+                .map(AttributeInfo::getName)
+                .collect(Collectors.toSet());
+        this.cob = new ConnectorObjectBuilder();
+        this.cob.setObjectClass(oclass);
+    }
+
+    public ConnectorObject build() {
+        if (!missedAttributes.isEmpty()) {
+            String className = this.oclass.getDisplayNameKey();
+            LOGGER.warn("Skip next attributes, which is not defined in schema for class: {0} :", className, missedAttributes.toString());
+            missedAttributes.stream().forEach(LOGGER::warn);
+        }
+        return cob.build();
+    }
+
+    public ConnectorObjectBuilderWrapper setUid(String uid) {
+        cob.setUid(uid);
+        return this;
+    }
+      
+    public ConnectorObjectBuilderWrapper setUid(Uid uid) {
+        cob.setUid(uid);
+        return this;
+    }
+      
+    public ConnectorObjectBuilderWrapper setName(String name) {
+        cob.setName(name);
+        return this;
+    }
+      
+    public ConnectorObjectBuilderWrapper setName(Name name) {
+        cob.setName(name);
+        return this;
+    }
+
+    public ConnectorObjectBuilderWrapper addAttribute(Attribute... attrs) {
+        if (checkAttributes(attrs)) {
+            cob.addAttribute(attrs);
+        }
+        return this;
+    }
+      
+    public ConnectorObjectBuilderWrapper addAttributes(Collection<Attribute> attrs) {
+        if (checkAttributes(attrs)) {
+            cob.addAttributes(attrs);
+        }
+        return this;
+    }
+      
+    public ConnectorObjectBuilderWrapper addAttribute(String name, Object... objs) {
+        if (checkAttribute(name)) {
+            cob.addAttribute(name, objs);
+        }
+        return this;
+    }
+
+    public ConnectorObjectBuilderWrapper addAttribute(String name, Collection<?> obj) {
+        if (checkAttribute(name)) {
+            cob.addAttribute(name, obj);
+        }
+        return this;
+    }
+
+    private boolean checkAttribute(Attribute attribute) {
+        String name = attribute.getName();
+        if (!attributesName.contains(name)) {
+            missedAttributes.add(name);
+            return false;
+        }
+        return true;
+    }
+
+    private boolean checkAttribute(String name) {
+        if (!attributesName.contains(name)) {
+            missedAttributes.add(name);
+            return false;
+        }
+        return true;
+    }
+
+    private boolean checkAttributes(Collection<Attribute> attrs) {
+        List<String> localMissedAttrubutes = attrs
+                .stream()
+                .filter(this::checkAttribute)
+                .map(Attribute::getName)
+                .collect(Collectors.toList());
+        missedAttributes.addAll(localMissedAttrubutes);
+        return localMissedAttrubutes.isEmpty();
+    }
+
+    private boolean checkAttributes(Attribute... attrs) {
+        List<String> localMissedAttrubutes = Arrays.stream(attrs)
+                .filter(this::checkAttribute)
+                .map(Attribute::getName)
+                .collect(Collectors.toList());
+        missedAttributes.addAll(localMissedAttrubutes);
+        return localMissedAttrubutes.isEmpty();
+    }
+}

--- a/src/main/java/com/evolveum/polygon/scim/common/ConnectorObjectBuilderWrapper.java
+++ b/src/main/java/com/evolveum/polygon/scim/common/ConnectorObjectBuilderWrapper.java
@@ -51,8 +51,7 @@ public class ConnectorObjectBuilderWrapper {
     public ConnectorObject build() {
         if (!missedAttributes.isEmpty()) {
             String className = this.oclass.getDisplayNameKey();
-            LOGGER.warn("Skip next attributes, which is not defined in schema for class: {0} :", className, missedAttributes.toString());
-            missedAttributes.stream().forEach(LOGGER::warn);
+            LOGGER.warn("The attributes \"{0}\" were omitted from the connId object {1} build.", missedAttributes.toString(), className);
         }
         return cob.build();
     }


### PR DESCRIPTION
Slack account, group schemas are evolved and not all attributes are presented now in User and Group schemas, due to outdate connector state.
I added simple wrapper over ConnectorObjectBuilder to handle and log missed attributes that are in slack account json schema, but still not added to schema definition.