### PR TITLE
Members attribute as multiValued

### DIFF
--- a/src/main/java/com/evolveum/polygon/scim/GroupDataBuilder.java
+++ b/src/main/java/com/evolveum/polygon/scim/GroupDataBuilder.java
@@ -56,8 +56,18 @@ public class GroupDataBuilder {
 		builder.addAttributeInfo(AttributeInfoBuilder.define("members.User.value").build());
 		builder.addAttributeInfo(AttributeInfoBuilder.define("members.User.display").build());
 
-		builder.addAttributeInfo(AttributeInfoBuilder.define("members.default.value").build());
-		builder.addAttributeInfo(AttributeInfoBuilder.define("members.default.display").build());
+		builder.addAttributeInfo(
+				AttributeInfoBuilder
+						.define("members.default.value")
+						.setMultiValued(true)
+						.build()
+		);
+		builder.addAttributeInfo(
+				AttributeInfoBuilder
+						.define("members.default.display")
+						.setMultiValued(true)
+						.build()
+		);
 		ObjectClassInfo groupSchemaInfo = builder.build();
 
 		LOGGER.info("The constructed group schema representation: {0}", groupSchemaInfo);


### PR DESCRIPTION
Set members attribute as multiValued to be able to remove association.
Before the fix: account can be added to a group, but can't be removed (removeAttributeValues is not invoked)
After the fix: account can be added to group, account can be removed from a group